### PR TITLE
Persist documents that are due and update documents message

### DIFF
--- a/app/campaign_messages/list_of_documents_message.rb
+++ b/app/campaign_messages/list_of_documents_message.rb
@@ -2,7 +2,7 @@ class ListOfDocumentsMessage < CampaignMessage
   attr_reader :contact
 
   def self.recipients
-    Contact.opted_in.not_received_message(self)
+    Contact.opted_in.with_documents_due.not_received_message(self)
   end
 
   def initialize(contact)
@@ -10,9 +10,14 @@ class ListOfDocumentsMessage < CampaignMessage
   end
 
   def send_message
-    body = "To complete your Medicaid renewal, please submit the following documents by DATE:\n\n"\
-           "You can drop them off at a Medicaid office, or submit them online at sspweb.lameds.ldh.la.gov/selfservice/ "\
-           "You can also email them (along with your case number) to mymedicaid@la.gov"
+    body = "To complete your Medicaid renewal, please submit the following documents by #{due_date}:\n\n"
+
+    contact.documents.each do |document|
+      body += "* #{document}\n"
+    end
+
+    body += "You can drop them off at a Medicaid office, or submit them online at sspweb.lameds.ldh.la.gov/selfservice/. "\
+            "You can also email them (along with your case number) to mymedicaid@la.gov."
 
     message = contact.messages.create!(
       message_type: self.class.name,
@@ -22,5 +27,11 @@ class ListOfDocumentsMessage < CampaignMessage
     )
 
     SmsService.send_message(message)
+  end
+
+  private
+
+  def due_date
+    contact.documents_due_date.strftime("%B %-d")
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -2,15 +2,17 @@
 #
 # Table name: contacts
 #
-#  id           :bigint           not null, primary key
-#  carrier_type :text
-#  first_name   :text
-#  last_name    :text
-#  opted_in     :boolean
-#  phone_number :text
-#  renewal_date :date
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                 :bigint           not null, primary key
+#  carrier_type       :text
+#  documents          :text             default([]), is an Array
+#  documents_due_date :date
+#  first_name         :text
+#  last_name          :text
+#  opted_in           :boolean
+#  phone_number       :text
+#  renewal_date       :date
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 
 class Contact < ApplicationRecord
@@ -21,6 +23,7 @@ class Contact < ApplicationRecord
   scope :opted_in, -> { where(opted_in: true) }
   scope :received_message, ->(message_class) { joins(:messages).merge(Message.with_type(message_class)).distinct }
   scope :not_received_message, ->(message_class) { where.not(id: unscoped.received_message(message_class).select(:id)) }
+  scope :with_documents_due, -> { where.not(documents: []).where.not(documents_due_date: nil) }
 
   def phone_number=(value)
     super(PhoneNumber.format(value))

--- a/db/migrate/20190813130813_add_documents_to_contacts.rb
+++ b/db/migrate/20190813130813_add_documents_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddDocumentsToContacts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :contacts, :documents, :text, array: true, default: []
+    add_column :contacts, :documents_due_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_05_171508) do
+ActiveRecord::Schema.define(version: 2019_08_13_130813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2019_08_05_171508) do
     t.text "first_name"
     t.text "last_name"
     t.text "carrier_type"
+    t.text "documents", default: [], array: true
+    t.date "documents_due_date"
   end
 
   create_table "messages", force: :cascade do |t|

--- a/spec/system/list_of_documents_message_spec.rb
+++ b/spec/system/list_of_documents_message_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "List of Documents Message spec Message", type: :system do
     Contact.create(
       first_name: "Brian",
       phone_number: "5551231234",
-      renewal_date: "2019/01/05",
+      documents_due_date: "2019/01/15",
+      documents: ["Document 1", "Document 2"],
       opted_in: true
     )
 
@@ -22,6 +23,8 @@ RSpec.describe "List of Documents Message spec Message", type: :system do
 
     expect(twilio_messages).to have_received(:create) do |args|
       expect(args[:body]).to include "To complete your Medicaid renewal, please submit the following documents by"
+      expect(args[:body]).to include "January 15"
+      expect(args[:body]).to include "* Document 1\n* Document 2"
     end
   end
 end


### PR DESCRIPTION
- Adds additional columns to `Contact` to store document descriptions and their due date.
- Updates the `ListOfDocumentsMessage` to query and author the message 