### PR TITLE
Send NoReplyMessage if someone replies with unexpected message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-email'
+  gem 'climate_control'
   gem 'launchy', require: false
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       mail
     childprocess (1.0.1)
       rake (< 13.0)
+    climate_control (0.2.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -271,6 +272,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-email
+  climate_control
   coffee-rails (~> 4.2)
   eefgilm
   factory_bot_rails

--- a/app/campaign_messages/campaign_message.rb
+++ b/app/campaign_messages/campaign_message.rb
@@ -1,5 +1,5 @@
 class CampaignMessage
-  attr_reader :campaign
+  attr_reader :contact
 
   def self.recipients
     raise 'Not Implemented'
@@ -19,6 +19,7 @@ class CampaignMessage
     @contact = contact
   end
 
-  def on_reply(message)
+  def on_reply(reply_message)
+    NoReplyMessage.new(contact).on_reply(reply_message)
   end
 end

--- a/app/campaign_messages/list_of_documents_message.rb
+++ b/app/campaign_messages/list_of_documents_message.rb
@@ -1,12 +1,6 @@
 class ListOfDocumentsMessage < CampaignMessage
-  attr_reader :contact
-
   def self.recipients
     Contact.opted_in.with_documents_due.not_received_message(self)
-  end
-
-  def initialize(contact)
-    @contact = contact
   end
 
   def send_message

--- a/app/campaign_messages/no_reply_message.rb
+++ b/app/campaign_messages/no_reply_message.rb
@@ -1,0 +1,20 @@
+class NoReplyMessage < CampaignMessage
+  PREVENT_RESEND_DAYS = 1.day
+
+  def on_reply(_reply_message)
+    has_recent_message = contact.messages.with_type(self.class).where('created_at > ?', PREVENT_RESEND_DAYS.ago).any?
+    return if has_recent_message
+
+    body = "We're unable to confirm any details about your case over text message. "\
+           "Please call 1-888-342-6207 for questions about your case."
+
+    message = contact.messages.create!(
+      message_type: self.class.name,
+      to_phone_number: contact.phone_number,
+      body: body,
+      outbound: true
+    )
+
+    SmsService.send_message(message)
+  end
+end

--- a/app/campaign_messages/opt_in_message.rb
+++ b/app/campaign_messages/opt_in_message.rb
@@ -1,12 +1,6 @@
 class OptInMessage < CampaignMessage
-  attr_reader :contact
-
   def self.recipients
     Contact.where(opted_in: nil).mobile.not_received_message(self)
-  end
-
-  def initialize(contact)
-    @contact = contact
   end
 
   def send_message
@@ -25,8 +19,8 @@ class OptInMessage < CampaignMessage
     SmsService.send_message(message)
   end
 
-  def on_reply(message)
-    clean_reply = message.body.downcase.strip
+  def on_reply(reply_message)
+    clean_reply = reply_message.body.downcase.strip
 
     if clean_reply.match Regexp.union([/\Ay\z/, /yes/i])
       contact.update opted_in: true
@@ -54,6 +48,8 @@ class OptInMessage < CampaignMessage
       )
 
       SmsService.send_message(message)
+    else
+      NoReplyMessage.new(contact).on_reply(reply_message)
     end
   end
 end

--- a/app/campaign_messages/renewal_notice_message.rb
+++ b/app/campaign_messages/renewal_notice_message.rb
@@ -1,12 +1,6 @@
 class RenewalNoticeMessage < CampaignMessage
-  attr_reader :contact
-
   def self.recipients
     Contact.opted_in.not_received_message(self)
-  end
-
-  def initialize(contact)
-    @contact = contact
   end
 
   def send_message

--- a/app/controllers/twilio/incomings_controller.rb
+++ b/app/controllers/twilio/incomings_controller.rb
@@ -21,10 +21,13 @@ module Twilio
       return if contact.blank?
 
       last_message_type = contact.messages.where.not(message_type: nil).order(created_at: :desc).first&.message_type
-      return if last_message_type.blank?
 
-      campaign_message = last_message_type.constantize.new(contact)
-      campaign_message.on_reply(message)
+      if last_message_type.present?
+        campaign_message = last_message_type.constantize.new(contact)
+        campaign_message.on_reply(message)
+      else
+        NoReplyMessage.new(contact).on_reply(message)
+      end
     end
 
     private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -34,6 +34,6 @@ class Message < ApplicationRecord
   end
 
   def inbound=(value)
-    self.outbound = !value
+    self.outbound = value.nil? ? value : !value
   end
 end

--- a/spec/campaign_messages/campaign_message_spec.rb
+++ b/spec/campaign_messages/campaign_message_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CampaignMessage do
     it 'includes all descendants' do
       expect(CampaignMessage.all_message_classes).to contain_exactly(
                                                            ListOfDocumentsMessage,
+                                                           NoReplyMessage,
                                                            OptInMessage,
                                                            RenewalNoticeMessage
                                                          )

--- a/spec/lib/sms_service_spec.rb
+++ b/spec/lib/sms_service_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe SmsService do
+  let(:twilio_client) { instance_double(Twilio::REST::Client, messages: twilio_messages) }
+  let(:twilio_response) { OpenStruct.new(sid: "12345") }
+  let(:twilio_messages) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList, create: twilio_response) }
+
+  before do
+    allow(Twilio::REST::Client).to receive(:new).and_return(twilio_client)
+  end
+
+  around do |example|
+    with_modified_env(TWILIO_MESSAGE_SERVICE: 'MS12345') { example.run }
+  end
+
+  describe '.send_message' do
+    it 'sends the message body to the correct phone number' do
+      message = Message.create to_phone_number: "+12223334444", body: 'hello'
+
+      SmsService.send_message(message)
+
+      expect(twilio_messages).to have_received(:create) do |args|
+        expect(args[:messaging_service_sid]).to eq "MS12345"
+        expect(args[:to]).to eq message.to_phone_number
+        expect(args[:body]).to eq message.body
+      end
+    end
+
+    it 'saves the message id' do
+      message = Message.create to_phone_number: "+12223334444", body: 'hello'
+
+      SmsService.send_message(message)
+
+      expect(message.reload.twilio_id).to eq twilio_response.sid
+    end
+  end
+
+  describe '.send_sms' do
+    it 'sends a bare message' do
+      SmsService.send_sms(to: "+12223334444", body: 'hello')
+
+      expect(twilio_messages).to have_received(:create) do |args|
+        expect(args[:messaging_service_sid]).to eq "MS12345"
+        expect(args[:to]).to eq "+12223334444"
+        expect(args[:body]).to eq 'hello'
+      end
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,5 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Message, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#inbound=' do
+    it 'sets outbound to the opposite' do
+      message = Message.new
+      expect do
+        message.inbound = true
+      end.to change(message, :outbound).from(nil).to false
+
+      message = Message.new
+      expect do
+        message.inbound = false
+      end.to change(message, :outbound).from(nil).to true
+
+      message = Message.new
+      expect do
+        message.inbound = nil
+      end.not_to change(message, :outbound).from(nil)
+    end
+  end
 end

--- a/spec/support/climate_control.rb
+++ b/spec/support/climate_control.rb
@@ -1,0 +1,14 @@
+module ClimateControlSupport
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options) do
+      Rails.application.remove_instance_variable(:@secrets) if Rails.application.instance_variable_defined?(:@secrets)
+      block.call
+    end
+
+    Rails.application.remove_instance_variable(:@secrets) if Rails.application.instance_variable_defined?(:@secrets)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ClimateControlSupport
+end

--- a/spec/system/no_reply_message_spec.rb
+++ b/spec/system/no_reply_message_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "No reply message", type: :system do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let!(:contact) do
+    Contact.create(
+      first_name: "Brian",
+      phone_number: "5551231234",
+      renewal_date: "2019/01/05",
+      carrier_type: 'mobile'
+    )
+  end
+
+  before do
+    allow(SmsService).to receive(:send_message)
+  end
+
+  it "sends a reply only once when someone texts in" do
+    incoming_sms(phone_number: contact.phone_number, body: "Ask for help.")
+
+    expect(SmsService).to have_received(:send_message) do |message|
+      expect(message.to_phone_number).to eq contact.phone_number
+      expect(message.body).to include "We're unable to confirm any details about your case over text message."
+      expect(message.message_type).to eq 'NoReplyMessage'
+    end
+  end
+
+  it 'only replies once a day' do
+    incoming_sms(phone_number: contact.phone_number, body: "Ask for help.")
+    incoming_sms(phone_number: contact.phone_number, body: "Another help")
+    incoming_sms(phone_number: contact.phone_number, body: "Another help")
+
+    expect(SmsService).to have_received(:send_message).once
+
+    travel 1.5.days do
+      incoming_sms(phone_number: contact.phone_number, body: "Ask for help later.")
+
+      expect(SmsService).to have_received(:send_message).twice
+    end
+  end
+end

--- a/spec/system/opt_in_message_spec.rb
+++ b/spec/system/opt_in_message_spec.rb
@@ -1,65 +1,74 @@
 require "rails_helper"
 
 RSpec.describe "Opt In Messages", type: :system do
-  include ActiveSupport::Testing::TimeHelpers
-
-  let(:twilio_client) { instance_double(Twilio::REST::Client, messages: twilio_messages) }
-  let(:twilio_messages) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList, create: twilio_response) }
-
-  before do
-    allow(Twilio::REST::Client).to receive(:new).and_return(twilio_client)
-  end
-
-  it "affirmative opt-in" do
-    contact = Contact.create(
+  let!(:contact) do
+    Contact.create(
       first_name: "Brian",
       phone_number: "5551231234",
       renewal_date: "2019/01/05",
       carrier_type: 'mobile'
     )
+  end
 
+  before do
+    allow(SmsService).to receive(:send_message)
+  end
+
+  it "affirmative opt-in" do
     OptInMessage.send_to_recipients
 
-    expect(twilio_messages).to have_received(:create) do |args|
-      expect(args[:body]).to include "Louisiana Medicaid is testing out a text message reminder program."
+    expect(SmsService).to have_received(:send_message) do |message|
+      expect(message.body).to include "Louisiana Medicaid is testing out a text message reminder program."
+      expect(message.message_type).to eq "OptInMessage"
     end
-    expect(contact.messages.reload.last.message_type).to eq "OptInMessage"
 
-    RSpec::Mocks.space.proxy_for(twilio_messages).reset
-    allow(twilio_messages).to receive(:create).and_return(twilio_response)
+    RSpec::Mocks.space.proxy_for(SmsService).reset
+    allow(SmsService).to receive(:send_message)
 
-    # they affirmatively say yes
     incoming_sms(phone_number: contact.phone_number, body: "Yes")
 
     expect(contact.reload.opted_in).to eq true
-    expect(twilio_messages).to have_received(:create) do |args|
-      expect(args[:body]).to include "You have opted in to text messages about your Medicaid case."
+    expect(SmsService).to have_received(:send_message) do |message|
+      expect(message.to_phone_number).to eq contact.phone_number
+      expect(message.body).to include "You have opted in to text messages about your Medicaid case."
+      expect(message.message_type).to eq 'OptInMessage'
     end
 
-    inbound_message, confirmation_message = contact.messages.reload.last(2)
+    inbound_message, _confirmation_message = contact.messages.reload.last(2)
     expect(inbound_message.message_type).to eq nil
     expect(inbound_message.inbound?).to eq true
-
-    expect(confirmation_message.message_type).to eq "OptInMessage"
   end
 
   it 'negative opt out' do
-    contact = Contact.create(
-      first_name: "Nate",
-      phone_number: "5551231234",
-      renewal_date: "2019/01/15"
-    )
-
     OptInMessage.new(contact).send_message
 
-    RSpec::Mocks.space.proxy_for(twilio_messages).reset
-    allow(twilio_messages).to receive(:create).and_return(twilio_response)
+    RSpec::Mocks.space.proxy_for(SmsService).reset
+    allow(SmsService).to receive(:send_message)
 
     incoming_sms(phone_number: contact.phone_number, body: "no")
 
     expect(contact.reload.opted_in).to eq false
-    expect(twilio_messages).to have_received(:create) do |args|
-      expect(args[:body]).to include "You have opted out."
+    expect(SmsService).to have_received(:send_message) do |message|
+      expect(message.to_phone_number).to eq contact.phone_number
+      expect(message.body).to include "You have opted out."
+      expect(message.message_type).to eq 'OptInMessage'
+    end
+  end
+
+  it 'other message' do
+    OptInMessage.new(contact).send_message
+
+    RSpec::Mocks.space.proxy_for(SmsService).reset
+    allow(SmsService).to receive(:send_message)
+
+    incoming_sms(phone_number: contact.phone_number, body: "other")
+
+    expect(contact.reload.opted_in).to eq nil
+
+    expect(SmsService).to have_received(:send_message) do |message|
+      expect(message.to_phone_number).to eq contact.phone_number
+      expect(message.body).to include "We're unable to confirm any details about your case over text message."
+      expect(message.message_type).to eq 'NoReplyMessage'
     end
   end
 end

--- a/spec/system/renewal_message_spec.rb
+++ b/spec/system/renewal_message_spec.rb
@@ -1,31 +1,27 @@
 require "rails_helper"
 
 RSpec.describe "Renewal Message", type: :system do
-  include ActiveSupport::Testing::TimeHelpers
-
-  let(:twilio_client) { instance_double(Twilio::REST::Client, messages: twilio_messages) }
-  let(:twilio_messages) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList, create: twilio_response) }
-
-  before do
-    allow(Twilio::REST::Client).to receive(:new).and_return(twilio_client)
-  end
-
-  describe
-
-  it "sends a Renewal Notice with date" do
-    contact = Contact.create(
+  let!(:contact) do
+    Contact.create(
       first_name: "Brian",
       phone_number: "5551231234",
       renewal_date: "2019/01/05",
       opted_in: true
     )
+  end
 
+  before do
+    allow(SmsService).to receive(:send_message)
+  end
+
+  it "sends a Renewal Notice with date" do
     RenewalNoticeMessage.send_to_recipients
 
-    expect(twilio_messages).to have_received(:create) do |args|
-      expect(args[:body]).to include "It's time to renew your household's Medicaid coverage."
-      expect(args[:body]).to include "January 5"
+    expect(SmsService).to have_received(:send_message) do |message|
+      expect(message.to_phone_number).to eq contact.phone_number
+      expect(message.body).to include "It's time to renew your household's Medicaid coverage."
+      expect(message.body).to include "January 5"
+      expect(message.message_type).to eq "RenewalNoticeMessage"
     end
-    expect(contact.messages.reload.last.message_type).to eq "RenewalNoticeMessage"
   end
 end


### PR DESCRIPTION
- Creates `NoReplyMessage` class
- Cleans up behavior duplication between base `CampaignMessage` and its children
- Adds tests for `SmsService` and mock that in system tests instead of Twilio; the benefit of this is that tests are simpler.